### PR TITLE
Bumped the graphql-java and graphql-java-extended-scalars dependencies to v20.2

### DIFF
--- a/graphql-jpa-query-dependencies/pom.xml
+++ b/graphql-jpa-query-dependencies/pom.xml
@@ -11,13 +11,13 @@
   <packaging>pom</packaging>
 
   <properties>
-    <graphql-java.version>19.2</graphql-java.version>
+    <graphql-java.version>20.2</graphql-java.version>
     <hibernate-jpa-2.1-api.version>1.0.0.Final</hibernate-jpa-2.1-api.version>
     <evo-inflector.version>1.3</evo-inflector.version>
     <javax.interceptor-api.version>1.2.2</javax.interceptor-api.version>
     <javax.persistence-api.version>2.2</javax.persistence-api.version>
     <joda-time.version>2.10.5</joda-time.version>
-    <graphql-java-extended-scalars.version>19.0</graphql-java-extended-scalars.version>
+    <graphql-java-extended-scalars.version>20.2</graphql-java-extended-scalars.version>
   </properties>
 
   <dependencyManagement>

--- a/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
+++ b/graphql-jpa-query-schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
@@ -30,6 +30,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -68,6 +69,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.Ent
 import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult.AttributePropertyDescriptor;
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
 import com.introproventures.graphql.jpa.query.support.GraphQLSupport;
+import graphql.GraphQLContext;
 import graphql.GraphQLException;
 import graphql.execution.CoercedVariables;
 import graphql.execution.MergedField;
@@ -686,7 +688,9 @@ public final class GraphQLJpaQueryFactory {
 
                 Map<String, Object> fieldArguments = ValuesResolver.getArgumentValues(fieldDefinition.getArguments(),
                                                                                       values,
-                                                                                      new CoercedVariables(variables));
+                                                                                      new CoercedVariables(variables),
+                                                                                      GraphQLContext.getDefault(),
+                                                                                      Locale.getDefault());
 
                 DataFetchingEnvironment fieldEnvironment = wherePredicateEnvironment(environment,
                                                                                      fieldDefinition,
@@ -822,7 +826,8 @@ public final class GraphQLJpaQueryFactory {
                 );
 
                 Map<String, Object> arguments = (Map<String, Object>) ValuesResolver
-                    .getArgumentValues(fieldDef.getArguments(), Collections.singletonList(where), new CoercedVariables(variables))
+                    .getArgumentValues(fieldDef.getArguments(), Collections.singletonList(where),
+                                       new CoercedVariables(variables), GraphQLContext.getDefault(), Locale.getDefault())
                     .get(WHERE);
 
                 return getWherePredicate(cb, from, join, wherePredicateEnvironment(environment, fieldDef, arguments), where);


### PR DESCRIPTION
Bumped the graphql-java and graphql-java-extended-scalars to the latest current version (20.2). Also carried out a small change in GraphQLJpaQueryFactory by passing the default GraphQLContext and Local to getArgumentValues(..) in order to comply with the updates that were made to the method through the upgrades.