### PR TITLE
chore(deps): bumped the graphql-java and graphql-java-extended-scalars to v20.2

### DIFF
--- a/dependencies/pom.xml
+++ b/dependencies/pom.xml
@@ -15,10 +15,10 @@
 
   <properties>
     <spring-boot.version>3.0.6</spring-boot.version>
-    <graphql-java.version>19.5</graphql-java.version>
+    <graphql-java.version>20.2</graphql-java.version>
     <evo-inflector.version>1.3</evo-inflector.version>
     <joda-time.version>2.10.5</joda-time.version>
-    <graphql-java-extended-scalars.version>19.1</graphql-java-extended-scalars.version>
+    <graphql-java-extended-scalars.version>20.2</graphql-java-extended-scalars.version>
     <jakarta.persistence-api.version>3.1.0</jakarta.persistence-api.version>
   </properties>
 

--- a/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
+++ b/schema/src/main/java/com/introproventures/graphql/jpa/query/schema/impl/GraphQLJpaQueryFactory.java
@@ -35,6 +35,7 @@ import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.Ent
 import com.introproventures.graphql.jpa.query.schema.impl.EntityIntrospector.EntityIntrospectionResult.AttributePropertyDescriptor;
 import com.introproventures.graphql.jpa.query.schema.impl.PredicateFilter.Criteria;
 import com.introproventures.graphql.jpa.query.support.GraphQLSupport;
+import graphql.GraphQLContext;
 import graphql.GraphQLException;
 import graphql.execution.CoercedVariables;
 import graphql.execution.MergedField;
@@ -97,6 +98,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -703,7 +705,9 @@ public final class GraphQLJpaQueryFactory {
                     Map<String, Object> fieldArguments = ValuesResolver.getArgumentValues(
                         fieldDefinition.getArguments(),
                         values,
-                        new CoercedVariables(variables)
+                        new CoercedVariables(variables),
+                        GraphQLContext.getDefault(),
+                        Locale.getDefault()
                     );
 
                     DataFetchingEnvironment fieldEnvironment = wherePredicateEnvironment(
@@ -852,7 +856,9 @@ public final class GraphQLJpaQueryFactory {
                     .getArgumentValues(
                         fieldDef.getArguments(),
                         Collections.singletonList(where),
-                        new CoercedVariables(variables)
+                        new CoercedVariables(variables),
+                        GraphQLContext.getDefault(),
+                        Locale.getDefault()
                     )
                     .get(WHERE);
 


### PR DESCRIPTION
Bumped the graphql-java and graphql-java-extended-scalars dependencies to the latest current version 20.2. Also carried out a small change in GraphQLJpaQueryFactory.java, by passing the default GraphQLContext and Locale to getArgumentValues(..) in order to comply with the updates that were made to the method through the upgrades.